### PR TITLE
Update README with Step 4 in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The installation of this plugin is straightforward ... no compiling etc.
    * linux:
       * The user based installation path is at `~/.local/share/cura/[version number]/plugins`.
 3. Copy the extracted `Cura2MoonrakerPlugin`folder into the Cura plugins folder you located in step 2. Attention: In the user based windows installation you have to copy the unzipped plugin directory into a parent directory with the same name. Looks like `...\cura\[version number]\plugins\Cura2MoonrakerPlugin\Cura2MoonrakerPlugin`.
+4. Quit Cura and re-open Cura.
 
 ## How to Configure
 To configure your Moonraker 3D printer...


### PR DESCRIPTION
I updated Cura and had to re-install the plugin - until I quit and re-opened, I couldn't do the Configure section.  Updated docs with Step 4 in How to Install